### PR TITLE
Updated outdated package for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Here are some commands to install on some distributions.
 - On Arch run:
 
 ```sh
-sudo pacman -S gtk-engine-murrine
+yay -S gtk-engine-murrine
 ```
 
 - On Debian and derivatives run:


### PR DESCRIPTION
It seems as if gtk-engine-murrine is no longer directly available via pacman and has been moved to the AUR, therefore the way of acquring gtk-engine-murrine should be updated to be acquired through an AUR helper, such as yay or paru. With yay being the most popular AUR helper, I've changed to use this for acquiring this package.