### PR TITLE
thunar: fix colors a little bit

### DIFF
--- a/themes/src/sass/gtk/apps/_xfce.scss
+++ b/themes/src/sass/gtk/apps/_xfce.scss
@@ -246,10 +246,9 @@ dialog.xfsm-logout-dialog {
 
 	.sidebar.shortcuts-pane treeview.view {
 		background-color: $fill;
-		
-		&:drop(active),
+
 		&:selected {
-			@extend %selected_items;
+			@extend %selected_items_primary;
 		}
 	}
 

--- a/themes/src/sass/gtk/apps/_xfce.scss
+++ b/themes/src/sass/gtk/apps/_xfce.scss
@@ -217,11 +217,12 @@ dialog.xfsm-logout-dialog {
 	.standard-view.frame {
 		border: none;
 
-		widget.view {
+		.view {
 			// padding: $space-size; // Not work ?
+			background-color: $fill;
 
-			&:selected {
-				@extend %selected_items;
+			widget, widget:hover {
+				background-color: transparent;
 			}
 		}
 	}
@@ -240,7 +241,16 @@ dialog.xfsm-logout-dialog {
 	statusbar {
 		margin: 0 -10px;
 		padding: 0 4px;
-		border-top: 1px solid $divider;
+		background-color: $fill;
+	}
+
+	.sidebar.shortcuts-pane treeview.view {
+		background-color: $fill;
+		
+		&:drop(active),
+		&:selected {
+			@extend %selected_items;
+		}
 	}
 
 	> grid.horizontal


### PR DESCRIPTION
This PR improves look of thunar file manager a little bit, making it look closer to nautilus. Changed: background colors of the panes + different highlight for shortcuts side pane

## Previews

### Light - before
<img width="1147" height="515" alt="2026-04-02_15-52-49" src="https://github.com/user-attachments/assets/b06101ea-f92f-4316-a419-cb09175cfd3c" />

### Light - after
<img width="948" height="515" alt="2026-04-02_16-35-25" src="https://github.com/user-attachments/assets/defcb302-b13f-48e7-b9c2-e0b4dfab807d" />


### Dark - before
<img width="1127" height="509" alt="2026-04-02_15-54-19" src="https://github.com/user-attachments/assets/4df246ee-12d4-4d58-b0aa-11face400bbc" />

### Dark - after
<img width="952" height="513" alt="2026-04-02_16-37-50" src="https://github.com/user-attachments/assets/e74c9b2c-091d-49e8-8e30-afaad08d1996" />

